### PR TITLE
refactor: Removed LastUpdated field.

### DIFF
--- a/api/cases/models/cases.settings.json
+++ b/api/cases/models/cases.settings.json
@@ -55,9 +55,6 @@
     "TravelHistory": {
       "type": "string"
     },
-    "LastUpdated": {
-      "type": "date"
-    },
     "OnsetOfSymptoms": {
       "type": "date"
     },


### PR DESCRIPTION
Re: #2 

As suggested by @jhon-andrew [here](https://github.com/covid19zc/covid19zc-backend/issues/2#issuecomment-605636082), the LastUpdated field is removed. Instead, the front-end will use one of Strapi's default prop `updated_at` in the backend.