### PR TITLE
feat: PUI and PUM models

### DIFF
--- a/api/figures/config/routes.json
+++ b/api/figures/config/routes.json
@@ -1,0 +1,12 @@
+{
+    "routes": [
+        {
+            "method": "GET",
+            "path": "/figures",
+            "handler": "figures.index",
+            "config": {
+                "policies": []
+            }
+        }
+    ]
+}

--- a/api/figures/controllers/figures.js
+++ b/api/figures/controllers/figures.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { sanitizeEntity } = require('strapi-utils');
+const { convertRestQueryParams } = require('strapi-utils');
+
+/**
+ * A set of functions called "actions" for `Counter`
+ */
+
+module.exports = {
+  index: async ctx => {
+      const pumDataCount = await strapi.query('pum').count();
+      const puiDataCount = await strapi.query('pui').count();
+      const confirmedCasesCount = await strapi.query('cases').count();
+      const latestConfirmedCasesUpdated = await strapi.query('cases').find({ _sort: 'updated_at:desc' })
+    
+      const figures = {
+        pui: await strapi.query('pui').findOne({id: puiDataCount}),
+        pum: await strapi.query('pum').findOne({id: pumDataCount}),
+        confirmed: {
+          value: confirmedCasesCount,
+          updated_at: latestConfirmedCasesUpdated.shift().updated_at
+        }
+      }
+
+      return figures;
+  }
+};
+

--- a/api/pui/config/routes.json
+++ b/api/pui/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/puis",
+      "handler": "pui.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/puis/count",
+      "handler": "pui.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/puis/:id",
+      "handler": "pui.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/puis",
+      "handler": "pui.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/puis/:id",
+      "handler": "pui.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/puis/:id",
+      "handler": "pui.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/pui/controllers/pui.js
+++ b/api/pui/controllers/pui.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/pui/models/pui.js
+++ b/api/pui/models/pui.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Lifecycle callbacks for the `pui` model.
+ */
+
+module.exports = {
+  // Before saving a value.
+  // Fired before an `insert` or `update` query.
+  // beforeSave: async (model, attrs, options) => {},
+
+  // After saving a value.
+  // Fired after an `insert` or `update` query.
+  // afterSave: async (model, response, options) => {},
+
+  // Before fetching a value.
+  // Fired before a `fetch` operation.
+  // beforeFetch: async (model, columns, options) => {},
+
+  // After fetching a value.
+  // Fired after a `fetch` operation.
+  // afterFetch: async (model, response, options) => {},
+
+  // Before fetching all values.
+  // Fired before a `fetchAll` operation.
+  // beforeFetchAll: async (model, columns, options) => {},
+
+  // After fetching all values.
+  // Fired after a `fetchAll` operation.
+  // afterFetchAll: async (model, response, options) => {},
+
+  // Before creating a value.
+  // Fired before an `insert` query.
+  // beforeCreate: async (model, attrs, options) => {},
+
+  // After creating a value.
+  // Fired after an `insert` query.
+  afterCreate: async (model, attrs, options) => {
+    strapi.io.emit('pui.new', model.toJSON())
+  },
+
+  // Before updating a value.
+  // Fired before an `update` query.
+  // beforeUpdate: async (model, attrs, options) => {},
+
+  // After updating a value.
+  // Fired after an `update` query.
+  afterUpdate: async (model, attrs, options) => {
+    strapi.io.emit('pui.updated', model.toJSON())
+  },
+
+  // Before destroying a value.
+  // Fired before a `delete` query.
+  // beforeDestroy: async (model, attrs, options) => {},
+
+  // After destroying a value.
+  // Fired after a `delete` query.
+  // afterDestroy: async (model, attrs, options) => {}
+};

--- a/api/pui/models/pui.settings.json
+++ b/api/pui/models/pui.settings.json
@@ -1,0 +1,28 @@
+{
+  "kind": "collectionType",
+  "connection": "default",
+  "collectionName": "puis",
+  "info": {
+    "name": "PUI"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "Value": {
+      "type": "integer",
+      "required": true,
+      "min": 0
+    },
+    "DataUpdatedAt": {
+      "type": "datetime"
+    },
+    "Reference": {
+      "collection": "file",
+      "via": "related",
+      "plugin": "upload",
+      "required": false
+    }
+  }
+}

--- a/api/pui/services/pui.js
+++ b/api/pui/services/pui.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/pum/config/routes.json
+++ b/api/pum/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/pums",
+      "handler": "pum.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/pums/count",
+      "handler": "pum.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/pums/:id",
+      "handler": "pum.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/pums",
+      "handler": "pum.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/pums/:id",
+      "handler": "pum.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/pums/:id",
+      "handler": "pum.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/pum/controllers/pum.js
+++ b/api/pum/controllers/pum.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/pum/models/pum.js
+++ b/api/pum/models/pum.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Lifecycle callbacks for the `pum` model.
+ */
+
+module.exports = {
+  // Before saving a value.
+  // Fired before an `insert` or `update` query.
+  // beforeSave: async (model, attrs, options) => {},
+
+  // After saving a value.
+  // Fired after an `insert` or `update` query.
+  // afterSave: async (model, response, options) => {},
+
+  // Before fetching a value.
+  // Fired before a `fetch` operation.
+  // beforeFetch: async (model, columns, options) => {},
+
+  // After fetching a value.
+  // Fired after a `fetch` operation.
+  // afterFetch: async (model, response, options) => {},
+
+  // Before fetching all values.
+  // Fired before a `fetchAll` operation.
+  // beforeFetchAll: async (model, columns, options) => {},
+
+  // After fetching all values.
+  // Fired after a `fetchAll` operation.
+  // afterFetchAll: async (model, response, options) => {},
+
+  // Before creating a value.
+  // Fired before an `insert` query.
+  // beforeCreate: async (model, attrs, options) => {},
+
+  // After creating a value.
+  // Fired after an `insert` query.
+  afterCreate: async (model, attrs, options) => {
+    strapi.io.emit('pum.new', model.toJSON())
+  },
+
+  // Before updating a value.
+  // Fired before an `update` query.
+  // beforeUpdate: async (model, attrs, options) => {},
+
+  // After updating a value.
+  // Fired after an `update` query.
+  afterUpdate: async (model, attrs, options) => {
+    strapi.io.emit('pum.updated', model.toJSON())
+  },
+
+  // Before destroying a value.
+  // Fired before a `delete` query.
+  // beforeDestroy: async (model, attrs, options) => {},
+
+  // After destroying a value.
+  // Fired after a `delete` query.
+  // afterDestroy: async (model, attrs, options) => {}
+};

--- a/api/pum/models/pum.settings.json
+++ b/api/pum/models/pum.settings.json
@@ -1,0 +1,28 @@
+{
+  "kind": "collectionType",
+  "connection": "default",
+  "collectionName": "persons_under_monitorings",
+  "info": {
+    "name": "PUM"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "Value": {
+      "type": "integer",
+      "required": true,
+      "min": 0
+    },
+    "DataUpdatedAt": {
+      "type": "datetime"
+    },
+    "Reference": {
+      "collection": "file",
+      "via": "related",
+      "plugin": "upload",
+      "required": false
+    }
+  }
+}

--- a/api/pum/services/pum.js
+++ b/api/pum/services/pum.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};


### PR DESCRIPTION
Re: #12 

- Added PUI and PUM data models in the API, as well as their respective controllers.

- Added `/figures` route, which outputs the updated counts:
```
{
    "pui": {
        "id": 1,
        "IncreasedBy": 0,
        "DecreasedBy": 0,
        "CurrentValue": 55,
        "DataUpdatedAt": "2020-04-02T04:00:00.000Z",
        "created_at": "2020-04-04T02:24:11.967Z",
        "updated_at": "2020-04-04T02:24:11.967Z",
        "Reference": []
    },
    "pum": {
        "id": 1,
        "IncreasedBy": 0,
        "DecreasedBy": 0,
        "CurrentValue": 2381,
        "DataUpdatedAt": "2020-04-01T14:27:00.000Z",
        "created_at": "2020-04-04T02:24:44.299Z",
        "updated_at": "2020-04-04T02:24:44.299Z",
        "Reference": []
    },
    "confirmed": {
        "value": 1,
        "updated_at": "2020-04-05T08:36:00Z"
    }
}
```