### PR TITLE
fix: Made date outputs into human readable format.

### DIFF
--- a/api/cases/controllers/cases.js
+++ b/api/cases/controllers/cases.js
@@ -51,6 +51,22 @@ module.exports = {
                 cases.Elderly = true;
             else
                 cases.Elderly = false;
+
+            // Changes the `created_at` and `updated_at` to human-readable format.
+            const dateFormat = {
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: 'numeric'
+            }
+
+            var humanReadableCreatedAt = new Date(cases.created_at)
+            var humanReadableUpdatedAt = new Date(cases.updated_at)
+
+            cases.created_at = humanReadableCreatedAt.toLocaleString('en-PH', dateFormat)
+            cases.updated_at = humanReadableUpdatedAt.toLocaleString('en-PH', dateFormat)
+
             return cases;
         });
     },

--- a/api/cases/models/cases.settings.json
+++ b/api/cases/models/cases.settings.json
@@ -66,6 +66,10 @@
       "type": "string",
       "required": true
     },
+    "dateUpdatedAt": {
+      "type": "string",
+      "required": true
+    },
     "barangay": {
       "model": "barangay"
     }

--- a/api/figures/controllers/figures.js
+++ b/api/figures/controllers/figures.js
@@ -13,13 +13,16 @@ module.exports = {
       const puiDataCount = await strapi.query('pui').count();
       const confirmedCasesCount = await strapi.query('cases').count();
       const latestConfirmedCasesUpdated = await strapi.query('cases').find({ _sort: 'updated_at:desc' })
+
+      const pui = await strapi.query('pui').findOne({id: puiDataCount})
+      const pum = await strapi.query('pum').findOne({id: pumDataCount})
     
       const figures = {
-        pui: await strapi.query('pui').findOne({id: puiDataCount}),
-        pum: await strapi.query('pum').findOne({id: pumDataCount}),
+        pui: pui,
+        pum: pum,
         confirmed: {
           value: confirmedCasesCount,
-          updated_at: latestConfirmedCasesUpdated.shift().updated_at
+          updatedAtReadable: latestConfirmedCasesUpdated.shift().dateUpdatedAt
         }
       }
 

--- a/api/pui/models/pui.settings.json
+++ b/api/pui/models/pui.settings.json
@@ -16,7 +16,8 @@
       "min": 0
     },
     "dataUpdatedAt": {
-      "type": "datetime"
+      "type": "string",
+      "required": true
     },
     "reference": {
       "collection": "file",

--- a/api/pum/models/pum.settings.json
+++ b/api/pum/models/pum.settings.json
@@ -16,7 +16,8 @@
       "min": 0
     },
     "dataUpdatedAt": {
-      "type": "datetime"
+      "type": "string",
+      "required": true
     },
     "reference": {
       "collection": "file",


### PR DESCRIPTION
Re: #22 
- Made date outputs into human readable format (e.g. `April 9, 2020 7:17 PM` instead of `2020-04-09T19:17:00Z`)