### PR TITLE
refactor: change from PascalCase to camelCase.

### DIFF
--- a/api/articles/models/articles.settings.json
+++ b/api/articles/models/articles.settings.json
@@ -10,23 +10,23 @@
     "timestamps": true
   },
   "attributes": {
-    "Title": {
+    "title": {
       "type": "string",
       "required": true
     },
-    "Author": {
+    "author": {
       "type": "string",
       "required": false
     },
-    "SourceName": {
+    "sourceName": {
       "type": "string",
       "required": true
     },
-    "SourceUrl": {
+    "sourceUrl": {
       "type": "string",
       "required": true
     },
-    "PublishedDate": {
+    "publishedDate": {
       "type": "datetime",
       "required": true
     }

--- a/api/cases/models/cases.settings.json
+++ b/api/cases/models/cases.settings.json
@@ -10,59 +10,59 @@
     "timestamps": true
   },
   "attributes": {
-    "Case": {
+    "case": {
       "type": "string",
       "required": true,
       "unique": true
     },
-    "Age": {
+    "age": {
       "type": "integer",
       "min": 0
     },
-    "Gender": {
+    "gender": {
       "type": "string",
       "maxLength": 1,
       "minLength": 1,
       "required": true
     },
-    "Nationality": {
+    "nationality": {
       "type": "string"
     },
-    "DateOfLabConfirmation": {
+    "dateOfLabConfirmation": {
       "type": "date"
     },
-    "Exposure": {
+    "exposure": {
       "type": "string"
     },
-    "FacilityOfAdmission": {
+    "facilityOfAdmission": {
       "type": "string"
     },
-    "ArrivalDate": {
+    "arrivalDate": {
       "type": "date"
     },
-    "WithCoMorbidity": {
+    "withCoMorbidity": {
       "type": "boolean"
     },
-    "PreviousConditions": {
+    "previousConditions": {
       "type": "string"
     },
-    "Symptoms": {
+    "symptoms": {
       "type": "string"
     },
-    "ResultDate": {
+    "resultDate": {
       "type": "date"
     },
-    "TravelHistory": {
+    "travelHistory": {
       "type": "string"
     },
-    "OnsetOfSymptoms": {
+    "onsetOfSymptoms": {
       "type": "date"
     },
-    "CurrentLocation": {
+    "currentLocation": {
       "type": "string",
       "required": true
     },
-    "Status": {
+    "status": {
       "type": "string",
       "required": true
     },

--- a/api/pui/models/pui.settings.json
+++ b/api/pui/models/pui.settings.json
@@ -10,15 +10,15 @@
     "timestamps": true
   },
   "attributes": {
-    "Value": {
+    "value": {
       "type": "integer",
       "required": true,
       "min": 0
     },
-    "DataUpdatedAt": {
+    "dataUpdatedAt": {
       "type": "datetime"
     },
-    "Reference": {
+    "reference": {
       "collection": "file",
       "via": "related",
       "plugin": "upload",

--- a/api/pum/models/pum.settings.json
+++ b/api/pum/models/pum.settings.json
@@ -10,15 +10,15 @@
     "timestamps": true
   },
   "attributes": {
-    "Value": {
+    "value": {
       "type": "integer",
       "required": true,
       "min": 0
     },
-    "DataUpdatedAt": {
+    "dataUpdatedAt": {
       "type": "datetime"
     },
-    "Reference": {
+    "reference": {
       "collection": "file",
       "via": "related",
       "plugin": "upload",


### PR DESCRIPTION
Re: #23 
- Changed code convention from Pascal Case (e.g. `ArticleName`) to Camel Case (e.g. `articleCase`)

---
### WARNING
After merging this, the database has to be reset since the existing database **will not match** with the code anymore without requiring additional code revisions.